### PR TITLE
Run partial match in addition to polyfill match

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classlist-polyfill",
-  "version": "1.1.20150312",
+  "version": "1.1.20170228",
   "description": "Cross-browser JavaScript shim that fully implements element.classList (referenced on MDN)",
   "main": "src/index.js",
   "directories": {
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/eligrey/classList.js.git"
+    "url": "git+https://github.com/unimelb/classList.js.git"
   },
   "keywords": [
     "classList",

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ if ("document" in window.self) {
 
 // Full polyfill for browsers with no classList support
 // Including IE < Edge missing SVGElement.classList
-if (!("classList" in document.createElement("_")) 
+if (!("classList" in document.createElement("_"))
 	|| document.createElementNS && !("classList" in document.createElementNS("http://www.w3.org/2000/svg","g"))) {
 
 (function (view) {
@@ -184,7 +184,7 @@ if (objCtr.defineProperty) {
 
 }(window.self));
 
-} else {
+}
 // There is full or partial native classList support, so just check if we need
 // to normalize the add/remove and toggle APIs.
 
@@ -235,6 +235,3 @@ if (objCtr.defineProperty) {
 }());
 
 }
-
-}
-


### PR DESCRIPTION
IE11 is matching the polyfill check, but not redefining the `toggle` method to take a 2nd/force param.

Partial support is already guarded inside the else condition, so it does no harm to run this block of code _in addition to_ the (skipped) polyfill.